### PR TITLE
Fix Twitch Plays number of Ingredients

### DIFF
--- a/Assets/Bartending/Maker.cs
+++ b/Assets/Bartending/Maker.cs
@@ -544,9 +544,9 @@ void Awake()
                 .Select(inf => Regex.Match(inf, @"^\s*(\d+)\s+(\d+)\s*$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
                 .Select(m => new { Ingredient = int.Parse(m.Groups[1].Value), Amount = int.Parse(m.Groups[2].Value) })
                 .ToArray();
-            if (data.Any(inf => inf.Ingredient < 1 || inf.Ingredient > 6 || inf.Amount < 1 || inf.Amount > 20))
+            if (data.Any(inf => inf.Ingredient < 1 || inf.Ingredient > 5 || inf.Amount < 1 || inf.Amount > 20))
             {
-                yield return "sendtochaterror Ingredients must be 1–6 (reading order) and amount must be 1–20.";
+                yield return "sendtochaterror Ingredients must be 1–5 (reading order) and amount must be 1–20.";
                 yield break;
             }
             yield return null;


### PR DESCRIPTION
Twitch Play believes that there are 6 ingredients to use, while there are only 5. 